### PR TITLE
Ensures ModuleThermometer never gets added twice.

### DIFF
--- a/GameData/Thermometer/Thermometer.cfg
+++ b/GameData/Thermometer/Thermometer.cfg
@@ -1,4 +1,4 @@
-@PART
+@PART[*]:HAS[!MODULE[ModuleThermometer]]
 {
     MODULE
     {


### PR DESCRIPTION
Not a big deal, but it may improve robustness.